### PR TITLE
Fix game reload

### DIFF
--- a/dpg_sim_game/Game.gd
+++ b/dpg_sim_game/Game.gd
@@ -131,6 +131,8 @@ func ExitGame():
 	global.ResetGame()
 	$Header/PhaseHUD.ResetPhases()
 	for child in get_children():
+		if !(child is CanvasItem):
+			continue
 		child.visible = false
 	$PauseMenu.visible = false
 	$MainMenu.visible = true


### PR DESCRIPTION
After changing AudioStreamPlayer2D to AudioStreamPlayer, they no longer support the property "visible", which broke ExitGame() method in Game.gd. Added a condition that fixes it